### PR TITLE
Some minor contributions

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
         </dependency>
+		<dependency>
+			<groupId>commons-configuration</groupId>
+			<artifactId>commons-configuration</artifactId>
+		</dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/resources/archetype-resources/run.sh
+++ b/src/main/resources/archetype-resources/run.sh
@@ -21,5 +21,6 @@ APPHOME=home
 . apphome.sh
 
 mvn exec:java -Dapp.home=$APPHOME \
+              -Dconfig.file=$APPHOME/cfg/application.properties \
               -Dlogback.configurationFile=$APPHOME/cfg/logback.xml \
               -Dexec.args="$ARGS"

--- a/src/main/resources/archetype-resources/run.sh
+++ b/src/main/resources/archetype-resources/run.sh
@@ -21,6 +21,5 @@ APPHOME=home
 . apphome.sh
 
 mvn exec:java -Dapp.home=$APPHOME \
-              -Dconfig.file=$APPHOME/cfg/application.properties \
               -Dlogback.configurationFile=$APPHOME/cfg/logback.xml \
               -Dexec.args="$ARGS"

--- a/src/main/resources/archetype-resources/src/main/scala/Command.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/Command.scala
@@ -11,7 +11,7 @@ object Command {
 
   def main(args: Array[String]): Unit = {
     log.debug("Starting command line interface")
-    val ps = cmd.parse(args)
+    implicit val ps = cmd.parse(args)
 
     // Here, pass the parameters to the main application logic (possibly to an Akka actor).
   }

--- a/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
@@ -8,7 +8,7 @@ import java.net.URL
 
 import org.rogach.scallop.ScallopConf
 
-class CommandLineOptions (args: Array[String]) extends ScallopConf(args) {
+class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
   printedName = "${artifactId}";
   val _________ = " " * printedName.size
 

--- a/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
@@ -43,7 +43,7 @@ object CommandLineOptions {
     val props = {
       val ps = new PropertiesConfiguration()
       ps.setDelimiterParsingDisabled(true)
-      ps.load(System.getProperty("config.file"))
+      ps.load(new File(homeDir, "cfg/application.properties"))
 
       ps
     }

--- a/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
@@ -9,8 +9,8 @@ import java.net.URL
 import org.rogach.scallop.ScallopConf
 
 class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
-  val _________ = " " * printedName.size
   printedName = "${artifactId}"
+  val _________ = " " * printedName.length
 
   version(s"${symbol_dollar}printedName v${symbol_dollar}{Version()}")
   banner(s"""

--- a/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
@@ -9,8 +9,8 @@ import java.net.URL
 import org.rogach.scallop.ScallopConf
 
 class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
-  printedName = "${artifactId}";
   val _________ = " " * printedName.size
+  printedName = "${artifactId}"
 
   version(s"${symbol_dollar}printedName v${symbol_dollar}{Version()}")
   banner(s"""

--- a/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
@@ -6,9 +6,16 @@ package ${package}
 import java.io.{File, PrintWriter}
 import java.net.URL
 
+import nl.knaw.dans.easy.license.CommandLineOptions._
+import nl.knaw.dans.easy.license.Parameters
+import org.apache.commons.configuration.PropertiesConfiguration
 import org.rogach.scallop.ScallopConf
+import org.slf4j.LoggerFactory
 
 class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
+
+  import CommandLineOptions.log
+
   printedName = "${artifactId}"
   val _________ = " " * printedName.length
 
@@ -29,9 +36,22 @@ class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
 
 object CommandLineOptions {
 
+  val log = LoggerFactory.getLogger(getClass)
+
   def parse(args: Array[String]): Parameters = {
     val opts = new CommandLineOptions(args)
+    log.debug("Loading application properties ...")
+    val props = {
+      val homeDir = new File(System.getProperty("app.home"))
+      new PropertiesConfiguration(new File(homeDir, "cfg/application.properties"))
+    }
+    log.debug("Parsing command line ...")
+
     // Fill Parameters with values from command line
-    Parameters()
+    val params = Parameters()
+
+    log.debug(s"Using the following settings: ${symbol_dollar}params")
+
+    params
   }
 }

--- a/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
@@ -39,13 +39,17 @@ object CommandLineOptions {
   val log = LoggerFactory.getLogger(getClass)
 
   def parse(args: Array[String]): Parameters = {
-    val opts = new CommandLineOptions(args)
     log.debug("Loading application properties ...")
     val props = {
-      val homeDir = new File(System.getProperty("app.home"))
-      new PropertiesConfiguration(new File(homeDir, "cfg/application.properties"))
+      val ps = new PropertiesConfiguration()
+      ps.setDelimiterParsingDisabled(true)
+      ps.load(System.getProperty("config.file"))
+
+      ps
     }
+
     log.debug("Parsing command line ...")
+    val opts = new CommandLineOptions(args)
 
     // Fill Parameters with values from command line
     val params = Parameters()

--- a/src/main/resources/archetype-resources/src/main/scala/package.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/package.scala
@@ -1,5 +1,7 @@
 package ${groupId}
 
+import java.util.Properties
+
 package object ${moduleSubpackage} {
 
   case class Parameters(/* Insert parameters */) {
@@ -9,8 +11,8 @@ package object ${moduleSubpackage} {
 
   object Version {
     def apply(): String = {
-      val props = new java.util.Properties()
-      props.load(Version.getClass.getResourceAsStream("/Version.properties"))
+      val props = new Properties()
+      props.load(getClass.getResourceAsStream("/Version.properties"))
       props.getProperty("application.version")
     }
   }

--- a/src/main/resources/archetype-resources/src/main/scala/package.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/package.scala
@@ -4,6 +4,8 @@ import java.util.Properties
 
 package object ${moduleSubpackage} {
 
+  val homeDir = new File(System.getProperty("app.home"))
+
   case class Parameters(/* Insert parameters */) {
     override def toString: String =
       s"<Replace with nicely formatted string with name-value style output of parameters>"

--- a/src/main/resources/archetype-resources/src/main/scala/package.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/package.scala
@@ -1,7 +1,8 @@
 package ${groupId}
 
 package object ${moduleSubpackage} {
-  case class Parameters(/* Insert parameters */){
+
+  case class Parameters(/* Insert parameters */) {
     override def toString: String =
       s"<Replace with nicely formatted string with name-value style output of parameters>"
   }

--- a/src/main/resources/archetype-resources/src/test/scala/CommandSpec.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/CommandSpec.scala
@@ -1,4 +1,4 @@
-package ${package};
+package ${package}
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._


### PR DESCRIPTION
Found some small improvements for he archetype. Besides some spaces and semicolons, two changes are more noteworthy:
1. The `ps: Parameters` are implicit now, such that they are conform the other projects that have `ss: Settings` as an implicit value as well
2. I changed `printedName.size` to `printedName.length` according to Intellij's inspections:

> This inspection reports array.size and string.size calls.
> 
> While such calls are legitimate, they require an additional implicit
> conversion to SeqLike to be made.
> 
> Considering the common use cases, calling length on arrays and strings
> may provide significant advantages.

I already applied these changes by hand to the newly created easy-license-creator project.

@DANS-KNAW/easy please review