### PR TITLE
Add the github PRtemplate so it will be included in new modules

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -37,6 +37,9 @@
 				<include>**/assembly/**/*</include>
 			</includes>
 		</fileSet>
+		<fileSet filtered="false" encoding="UTF-8">
+			<directory>.github</directory>
+		</fileSet>
 		<fileSet filtered="true" encoding="UTF-8">
 			<directory></directory>
 			<includes>

--- a/src/main/resources/archetype-resources/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/main/resources/archetype-resources/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+fixes EASY-
+
+#### When applied it will
+* 
+* 
+* 
+
+#### Where should the reviewer @DANS-KNAW/easy start?
+
+#### How should this be manually tested?
+
+#### related pull requests on github
+repo                       | PR
+-------------------------- | -----------------
+easy-                      | [PR#](PRlink) 


### PR DESCRIPTION
fixes EASY-1068

#### When applied it will
* Add the github PRtemplate so it will be included in new modules

#### How should this be manually tested?
* run the mvn archetype:generate command 
* notice the .github/PULL_REQUEST_TEMPLATE.md is in the new module

