### PR TITLE
Parent upgrade and remove hardcoded Scallop version

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.34</version>
+        <version>1.35</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>${groupId}</groupId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
+            <version>2.0.2</version>
         </dependency>
 		<dependency>
 			<groupId>commons-configuration</groupId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.32</version>
+        <version>1.34</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>${groupId}</groupId>
@@ -54,7 +54,6 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
-            <version>2.0.2</version>
         </dependency>
 		<dependency>
 			<groupId>commons-configuration</groupId>

--- a/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
@@ -16,6 +16,9 @@ class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
 
   import CommandLineOptions.log
 
+  appendDefaultToDescription = true
+  editBuilder(_.setHelpWidth(110))
+
   printedName = "${artifactId}"
   val _________ = " " * printedName.length
 
@@ -31,7 +34,9 @@ class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
            |Options:
            |""".stripMargin)
   //val url = opt[String]("someOption", noshort = true, descr = "Description of the option", default = Some("Default value"))
+
   footer("")
+  verify()
 }
 
 object CommandLineOptions {


### PR DESCRIPTION
fixes [EASY-1049](https://drivenbydata.atlassian.net/browse/EASY-1049)

#### When applied it will
* upgrade the project's parent project to version 1.35
* incorporate the changes for Scallop in this archetype

#### Where should the reviewer @DANS-KNAW/easy start?
`pom.xml`