### PR TITLE
Readme checks

### DIFF
--- a/easy-module/pom.xml
+++ b/easy-module/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+    Copyright (C) 2015-2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -24,18 +24,18 @@
         <version>1.35</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>${groupId}</groupId>
-    <artifactId>${artifactId}</artifactId>
-    <version>${version}</version>
-    <name>${name}</name>
-    <url>https://github.com/DANS-KNAW/${artifactId}</url>
-    <description>${description}</description>
+    <groupId>nl.knaw.dans.easy</groupId>
+    <artifactId>easy-module</artifactId>
+    <version>1.x-SNAPSHOT</version>
+    <name>EASY Module</name>
+    <url>https://github.com/DANS-KNAW/easy-module</url>
+    <description>A longer description of this module</description>
     <inceptionYear>2017</inceptionYear>
     <properties>
-        <main-class>${package}.Command</main-class>
+        <main-class>nl.knaw.dans.easy.module.Command</main-class>
     </properties>
     <scm>
-        <developerConnection>scm:git:https://github.com/DANS-KNAW/${artifactId}</developerConnection>
+        <developerConnection>scm:git:https://github.com/DANS-KNAW/easy-module</developerConnection>
         <tag>HEAD</tag>
     </scm>
     <dependencies>
@@ -55,10 +55,10 @@
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>commons-configuration</groupId>
+			<artifactId>commons-configuration</artifactId>
+		</dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/resources/archetype-resources/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/main/resources/archetype-resources/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@ fixes EASY-
 #### How should this be manually tested?
 
 #### related pull requests on github
-repo                       | PR
--------------------------- | -----------------
-easy-                      | [PR#](PRlink) 
+repo                       | PR                | note
+-------------------------- | ----------------- | ----
+easy-                      | [PR#](PRlink)     | ..

--- a/src/main/resources/archetype-resources/README.md
+++ b/src/main/resources/archetype-resources/README.md
@@ -14,7 +14,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-<Replace with a longer description of this module>
+${description}
 
 
 ARGUMENTS

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+    Copyright (C) 2015-2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/main/resources/archetype-resources/run.sh
+++ b/src/main/resources/archetype-resources/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+# Copyright (C) 2015-2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/archetype-resources/run.sh
+++ b/src/main/resources/archetype-resources/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2015-2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/archetype-resources/src/main/assembly/bin.xml
+++ b/src/main/resources/archetype-resources/src/main/assembly/bin.xml
@@ -2,46 +2,63 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-	<id>bin</id>
-	<baseDirectory>${symbol_dollar}{artifactId}-${symbol_dollar}{version}</baseDirectory>
-	<formats>
-		<format>tar.gz</format>
-	</formats>
-	<fileSets>
-		<fileSet>
-			<directory>${symbol_dollar}{project.build.directory}</directory>
-			<outputDirectory>/bin</outputDirectory>
-			<includes>
-				<include>*.jar</include>
-			</includes>
-			<excludes>
-				<exclude>*.sh</exclude>
-			</excludes>
-		</fileSet>
-		<fileSet>
-			<directory>${symbol_dollar}{project.basedir}/src/main/assembly/dist/bin</directory>
-			<outputDirectory>/bin</outputDirectory>
-			<includes>
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>bin</id>
+    <baseDirectory>${symbol_dollar}{artifactId}-${symbol_dollar}{version}</baseDirectory>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${symbol_dollar}{project.build.directory}</directory>
+            <outputDirectory>/bin</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*.sh</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${symbol_dollar}{project.basedir}/src/main/assembly/dist/bin</directory>
+            <outputDirectory>/bin</outputDirectory>
+            <includes>
                 <include>${artifactId}</include>
-			</includes>
-			<fileMode>0755</fileMode>
-		</fileSet>
-		<fileSet>
-			<directory>${symbol_dollar}{project.basedir}/src/main/assembly/dist</directory>
-			<outputDirectory>/</outputDirectory>
-			<excludes>
-				<exclude>/bin</exclude>
-			</excludes>
-		</fileSet>
-	</fileSets>
-	<dependencySets>
-		<dependencySet>
-			<outputDirectory>lib</outputDirectory>
-			<useProjectArtifact>false</useProjectArtifact>
-		</dependencySet>
-	</dependencySets>
+            </includes>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>${symbol_dollar}{project.basedir}/src/main/assembly/dist</directory>
+            <outputDirectory>/</outputDirectory>
+            <excludes>
+                <exclude>/bin</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
+    </dependencySets>
 </assembly>

--- a/src/main/resources/archetype-resources/src/main/scala/Command.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/Command.scala
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )

--- a/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/CommandLineOptions.scala
@@ -1,13 +1,27 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 package ${package}
 
-import java.io.{File, PrintWriter}
-import java.net.URL
+import java.io.File
 
 import ${package}.CommandLineOptions._
-import ${package}.Parameters
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.rogach.scallop.ScallopConf
 import org.slf4j.LoggerFactory
@@ -20,16 +34,18 @@ class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
   editBuilder(_.setHelpWidth(110))
 
   printedName = "${artifactId}"
-  val _________ = " " * printedName.length
+  val description = s"""${description}"""
+  val synopsis = s"""${symbol_dollar}printedName \\
+           |      <synopsis of command line parameters> \\
+           |      <...possibly continued again, or all joined on one line>""".stripMargin
 
   version(s"${symbol_dollar}printedName v${symbol_dollar}{Version()}")
   banner(s"""
-           |<Replace with one sentence describing the main task of this module>
+           |  ${symbol_dollar}description
            |
            |Usage:
            |
-           |${symbol_dollar}printedName <synopsis of command line parameters>
-           |${symbol_dollar}{_________} <...possibly continued here>
+           |  ${symbol_dollar}synopsis
            |
            |Options:
            |""".stripMargin)

--- a/src/main/resources/archetype-resources/src/main/scala/package.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/package.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ${groupId}
 
 import java.io.File

--- a/src/main/resources/archetype-resources/src/test/scala/CommandLineOptionsSpec.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/CommandLineOptionsSpec.scala
@@ -19,6 +19,9 @@ import java.io.{ByteArrayOutputStream, File}
 
 import ${package}.CustomMatchers._
 
+import org.scalamock.scalatest.MockFactory
+import org.scalatest._
+
 class CommandLineOptionsSpec extends FlatSpec with Matchers {
 
   private val clo = new CommandLineOptions(Array[String]()) {

--- a/src/main/resources/archetype-resources/src/test/scala/CommandLineOptionsSpec.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/CommandLineOptionsSpec.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}
+
+import java.io.{ByteArrayOutputStream, File}
+
+import ${package}.CustomMatchers._
+
+class CommandLineOptionsSpec extends FlatSpec with Matchers {
+
+  private val clo = new CommandLineOptions(Array[String]()) {
+    // avoids System.exit() in case of invalid arguments or "--help"
+    override def verify(): Unit = {}
+  }
+
+  private val helpInfo = {
+    val mockedStdOut = new ByteArrayOutputStream()
+    Console.withOut(mockedStdOut) {
+      clo.printHelp()
+    }
+    mockedStdOut.toString
+  }
+
+  "options in help info" should "be part of README.md" in {
+    val lineSeparators = s"(${System.lineSeparator()})+"
+    val options = helpInfo.split(s"${lineSeparators}Options:$lineSeparators")(1)
+    options.trim.length shouldNot be (0)
+    new File("README.md") should containTrimmed(options)
+  }
+
+  "synopsis in help info" should "be part of README.md" in {
+    new File("README.md") should containTrimmed(clo.synopsis)
+  }
+
+  "description line(s) in help info" should "be part of README.md and pom.xml" in {
+    new File("README.md") should containTrimmed(clo.description)
+    new File("pom.xml") should containTrimmed(clo.description)
+  }
+}

--- a/src/main/resources/archetype-resources/src/test/scala/CommandSpec.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/CommandSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ${package}
 
 import org.scalamock.scalatest.MockFactory

--- a/src/main/resources/archetype-resources/src/test/scala/CustomMatchers.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/CustomMatchers.scala
@@ -17,7 +17,7 @@ package ${package}
 
 import java.io.File
 
-import scala.io.Source.fromFile
+import scala.io.Source
 
 import org.scalatest.matchers.{MatchResult, Matcher}
 
@@ -29,7 +29,7 @@ trait CustomMatchers {
     def apply(left: File): MatchResult = {
       def trimLines(s: String): String = s.split("\n").map(_.trim).mkString("\n")
       MatchResult(
-        trimLines(fromFile(left).mkString).contains(trimLines(content)),
+        trimLines(Source.fromFile(left).mkString).contains(trimLines(content)),
         s"$left did not contain: $content" ,
         s"$left contains $content"
       )

--- a/src/main/resources/archetype-resources/src/test/scala/CustomMatchers.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/CustomMatchers.scala
@@ -17,6 +17,9 @@ package ${package}
 
 import java.io.File
 
+import scala.io.Source.fromFile
+
+import org.scalatest.matchers.{MatchResult, Matcher}
 
 /** Does not dump the full file but just the searched content if it is not found.
   *
@@ -26,7 +29,7 @@ trait CustomMatchers {
     def apply(left: File): MatchResult = {
       def trimLines(s: String): String = s.split("\n").map(_.trim).mkString("\n")
       MatchResult(
-        trimLines(readFileToString(left)).contains(trimLines(content)),
+        trimLines(fromFile(left).mkString).contains(trimLines(content)),
         s"$left did not contain: $content" ,
         s"$left contains $content"
       )

--- a/src/main/resources/archetype-resources/src/test/scala/CustomMatchers.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/CustomMatchers.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}
+
+import java.io.File
+
+
+/** Does not dump the full file but just the searched content if it is not found.
+  *
+  * See also <a href="http://www.scalatest.org/user_guide/using_matchers#usingCustomMatchers">CustomMatchers</a> */
+trait CustomMatchers {
+  class ContentMatcher(content: String) extends Matcher[File] {
+    def apply(left: File): MatchResult = {
+      def trimLines(s: String): String = s.split("\n").map(_.trim).mkString("\n")
+      MatchResult(
+        trimLines(readFileToString(left)).contains(trimLines(content)),
+        s"$left did not contain: $content" ,
+        s"$left contains $content"
+      )
+    }
+  }
+  def containTrimmed(content: String) = new ContentMatcher(content)
+}
+object CustomMatchers extends CustomMatchers


### PR DESCRIPTION
fixes EASY-

#### When applied it will generate modules
* with 2017 as inception year and in license headers
* with readme checks
* that builds but for the readme checks as the command line arguments and synopsys in the scalop class should be implemented first

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

    mvn clean install -f ~/git/service/easy/easy-module-archetype
    rm -rf easy-module ; mvn archetype:generate -DarchetypeGroupId=nl.knaw.dans.easy \
                -DarchetypeArtifactId=easy-module-archetype \
                -DarchetypeVersion=1.x-SNAPSHOT \
                -DgroupId=nl.knaw.dans.easy \
                -DartifactId=easy-module \
                -Dpackage=nl.knaw.dans.easy.module \
                -DmoduleSubpackage=module \
                -Dname="EASY Module" \
                -Ddescription="A longer description of this module"
    mvn install -f easy-module

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
