### PR TITLE
PR33-comment: shell script should abort on error

### DIFF
--- a/src/main/resources/archetype-resources/debug-init-env.sh
+++ b/src/main/resources/archetype-resources/debug-init-env.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
-echo -n "Pre-creating log..."
+set -e # abort when a command fails
+
 TEMPDIR=data
+if [ -e $TEMPDIR ]; then
+    mv $TEMPDIR ${symbol_dollar}{TEMPDIR}-${symbol_dollar}(date  +"%Y-%m-%d@%H:%M:%S")
+fi
+mkdir $TEMPDIR
+
+echo -n "Pre-creating log..."
 touch $TEMPDIR/${artifactId}.log
 echo "OK"


### PR DESCRIPTION
fixes https://github.com/DANS-KNAW/easy-archive-bag/pull/33#discussion_r130339328

#### When applied it will
* generate a `debug-init-env.sh` that aborts on error and moves data to backup
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* build the archetype project
* run `generate-easy-module.sh` with the version in the pom: `1.2.1-SNAPSHOT`
* run the generated `debug-init-env.sh` at least twice, the second time it should have two `data*` folders
* enforce an error for example by making the `data` inaccessible and run again, the error message should not be followed by an `OK`

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
