### PR TITLE
parsing comma's in properties files

### DIFF
--- a/src/main/resources/archetype-resources/src/main/scala/Configuration.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/Configuration.scala
@@ -24,7 +24,10 @@ object Configuration {
 
     new Configuration(
       version = managed(Source.fromFile(home.resolve("bin/version").toFile)).acquireAndGet(_.mkString),
-      properties = new PropertiesConfiguration(cfgPath.resolve("application.properties").toFile)
+      properties = new PropertiesConfiguration() {
+        setDelimiterParsingDisabled(true)
+        load(cfgPath.resolve("application.properties").toFile)
+      }
     )
   }
 }


### PR DESCRIPTION
no issue

#### When applied it will
* don't let other developpers look in the wrong direction when properties with comma's are involved in the configuration
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

induced by https://github.com/DANS-KNAW/easy-update-solr4files-index/pull/9/commits/153cc8cb1c43e2aef14d9600b461234be5006d27

#### How should this be manually tested?

Create a new project and parse some property values with comma's as for example for ldap

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
