### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.62</version>
+        <version>1.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/main/resources/archetype-resources/Vagrantfile
+++ b/src/main/resources/archetype-resources/Vagrantfile
@@ -8,6 +8,8 @@ Vagrant.configure(2) do |config|
       test.vm.provision "ansible" do |ansible|
         ansible.playbook = "src/main/ansible/vagrant.yml"
         ansible.config_file = "src/main/ansible/ansible.cfg"
+        ansible.compatibility_mode = "2.0"
+#        ansible.verbose = "vvvv"
       end
       test.vm.provider "virtualbox" do |vb|
         vb.gui = false

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.62</version>
+        <version>1.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>${groupId}</groupId>
@@ -28,15 +28,15 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalamock</groupId>
-            <artifactId>scalamock-scalatest-support_2.11</artifactId>
+            <artifactId>scalamock-scalatest-support_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
+            <artifactId>scallop_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
@@ -44,11 +44,11 @@
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
+            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_2.11</artifactId>
+            <artifactId>scala-arm_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
+            <artifactId>scalatra_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-scalate_2.11</artifactId>
+            <artifactId>scalatra-scalate_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-daemon</groupId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>${groupId}</groupId>

--- a/src/main/resources/archetype-resources/src/main/scala/ServiceStarter.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/ServiceStarter.scala
@@ -5,8 +5,9 @@ package ${package}
 
 import java.nio.file.Paths
 
-import org.apache.commons.daemon.{ Daemon, DaemonContext }
+import nl.knaw.dans.lib.error.TryExtensions
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.daemon.{ Daemon, DaemonContext }
 
 class ServiceStarter extends Daemon with DebugEnhancedLogging {
   var app: ${javaName}App = _

--- a/src/main/resources/archetype-resources/src/main/scala/package.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/package.scala
@@ -1,16 +1,5 @@
 package ${groupId}
 
-import scala.util.{ Failure, Success, Try }
-
 package object ${moduleSubpackage} {
 
-  implicit class TryExtensions2[T](val t: Try[T]) extends AnyVal {
-    // TODO candidate for dans-scala-lib
-    def unsafeGetOrThrow: T = {
-      t match {
-        case Success(value) => value
-        case Failure(throwable) => throw throwable
-      }
-    }
-  }
 }


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* use the `dans-scala-lib` functions
* add `compatibility_mode` and extra if-clause to `Vagrantfile`

@DANS-KNAW/easy for review