### PR TITLE
EASY-1819 EASY systemd services worden niet netjes afgesloten onder CentOS7

### DIFF
--- a/src/main/resources/archetype-resources/src/main/assembly/dist/install/__artifactId__.service
+++ b/src/main/resources/archetype-resources/src/main/assembly/dist/install/__artifactId__.service
@@ -6,6 +6,8 @@ ExecStart=/bin/java \
    -Dlogback.configurationFile=/etc/opt/dans.knaw.nl/${artifactId}/logback-service.xml \
    -Dapp.home=/opt/dans.knaw.nl/${artifactId} \
    -jar /opt/dans.knaw.nl/${artifactId}/bin/${artifactId}.jar run-service
+# Java returns 143 even if the SIGTERM was handled correctly.
+SuccessExitStatus=143
 
 User=${artifactId}
 Group=${artifactId}


### PR DESCRIPTION
Fixes EASY-1819

#### When applied it will
* Update systemd unit definition

#### Where should the reviewer @DANS-KNAW/easy start?
One line changed

#### How should this be manually tested?
Create a service start and stop it and check with `journalctl` that it was stopped without failure.

#### References
* https://stegard.net/2016/08/gracefully-killing-a-java-process-managed-by-systemd/
* https://serverfault.com/questions/695849/services-remain-in-failed-state-after-stopped-with-systemctl
