### PR TITLE
EASY-2038: get archetype up to modern standards

### DIFF
--- a/generate-easy-module.sh
+++ b/generate-easy-module.sh
@@ -58,3 +58,4 @@ mvn archetype:generate -DarchetypeGroupId=nl.knaw.dans.easy \
 
 cd $ARTIFACT_ID
 sh init-project.sh
+rm init-project.sh

--- a/generate-easy-module.sh
+++ b/generate-easy-module.sh
@@ -53,7 +53,8 @@ mvn archetype:generate -DarchetypeGroupId=nl.knaw.dans.easy \
         -Dname="$MODULE_NAME" \
         -DjavaName="$MODULE_JAVA_NAME" \
         -Ddescription="$DESCRIPTION" \
-        -DuseLocalVM="$USE_LOCAL_VM"
+        -DuseLocalVM="$USE_LOCAL_VM" \
+        -DinceptionYear=$(date +"%Y")
 
 cd $ARTIFACT_ID
 sh init-project.sh

--- a/generate-easy-module.sh
+++ b/generate-easy-module.sh
@@ -18,6 +18,7 @@
 
 DEFAULT_ARCHETYPE_VERSION=2.0.3
 USE_LOCAL_VM=true
+PROJECT_PREFIX="easy"
 
 read -p "easy-module-archetype version? (default = $DEFAULT_ARCHETYPE_VERSION): " ARCHETYPE_VERSION
 read -p "Module artifactId (e.g., easy-test-module): " ARTIFACT_ID
@@ -38,16 +39,25 @@ useLocalVM() {
 }
 useLocalVM
 
+PROJECT_PREFIX_REGEX="^([^-]+)-.*$"
+if [[ "$ARTIFACT_ID" =~ $PROJECT_PREFIX_REGEX ]]; then
+    PROJECT_PREFIX=`echo "$ARTIFACT_ID" | sed -E "s/$PROJECT_PREFIX_REGEX/\1/"`
+else
+    echo "artifactId does not match the expected pattern; module is not generated"
+    exit 1
+fi
+
 ARTIFACT_PHRASE=`echo $ARTIFACT_ID | tr '-' ' ' | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1'`
-MODULE_NAME=`echo $ARTIFACT_PHRASE | sed -e 's/Easy/EASY/'`
+MODULE_NAME=`echo $ARTIFACT_PHRASE | awk '{$1=toupper($1); print $0}'`
 MODULE_JAVA_NAME=${ARTIFACT_PHRASE// }
 
 mvn archetype:generate -DarchetypeGroupId=nl.knaw.dans.easy \
         -DarchetypeArtifactId=easy-module-archetype \
         -DarchetypeVersion=${ARCHETYPE_VERSION:-"$DEFAULT_ARCHETYPE_VERSION"} \
-        -DgroupId=nl.knaw.dans.easy \
+        -DgroupId=nl.knaw.dans.$PROJECT_PREFIX \
         -DartifactId=$ARTIFACT_ID \
-        -Dpackage=nl.knaw.dans.easy.$SUBPACKAGE \
+        -Dpackage=nl.knaw.dans.$PROJECT_PREFIX.$SUBPACKAGE \
+        -DprojectPrefix=$PROJECT_PREFIX \
         -DmoduleSubpackage=$SUBPACKAGE \
         -DbackendPort="$BACK_END_PORT" \
         -Dname="$MODULE_NAME" \

--- a/generate-easy-module.sh
+++ b/generate-easy-module.sh
@@ -17,12 +17,26 @@
 
 
 DEFAULT_ARCHETYPE_VERSION=2.0.3
+USE_LOCAL_VM=true
 
 read -p "easy-module-archetype version? (default = $DEFAULT_ARCHETYPE_VERSION): " ARCHETYPE_VERSION
 read -p "Module artifactId (e.g., easy-test-module): " ARTIFACT_ID
 read -p "Name module's main package (i.e. the one UNDER nl.knaw.dans.easy): " SUBPACKAGE
 read -p "Description (one to four sentences): " DESCRIPTION
 read -p "Backend port number (IN THE 20000-RANGE THAT HAS NOT BEEN TAKEN YET): " BACK_END_PORT
+
+useLocalVM() {
+    read -r -p "Do you want to use a local VM with Ansible/Vagrant? (y/n, default = y): " result
+    
+    if [[ "$result" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+        USE_LOCAL_VM=true
+    elif [[ "$result" =~ ^([nN][oO]|[nN])+$ ]]; then
+        USE_LOCAL_VM=false
+    else
+        useLocalVM
+    fi
+}
+useLocalVM
 
 ARTIFACT_PHRASE=`echo $ARTIFACT_ID | tr '-' ' ' | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1'`
 MODULE_NAME=`echo $ARTIFACT_PHRASE | sed -e 's/Easy/EASY/'`
@@ -38,7 +52,8 @@ mvn archetype:generate -DarchetypeGroupId=nl.knaw.dans.easy \
         -DbackendPort="$BACK_END_PORT" \
         -Dname="$MODULE_NAME" \
         -DjavaName="$MODULE_JAVA_NAME" \
-        -Ddescription="$DESCRIPTION"
+        -Ddescription="$DESCRIPTION" \
+        -DuseLocalVM="$USE_LOCAL_VM"
 
 cd $ARTIFACT_ID
 sh init-project.sh

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -13,6 +13,7 @@
         <requiredProperty key="moduleSubpackage"/>
         <requiredProperty key="name"/>
         <requiredProperty key="package"/>
+        <requiredProperty key="projectPrefix"/>
         <requiredProperty key="version">
             <defaultValue>1.0.0-SNAPSHOT</defaultValue>
         </requiredProperty>

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -19,6 +19,7 @@
         <requiredProperty key="javaName"/>
         <requiredProperty key="backendPort"/>
         <requiredProperty key="useLocalVM"/>
+        <requiredProperty key="inceptionYear"/>
     </requiredProperties>
     <fileSets>
         <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -18,6 +18,7 @@
         </requiredProperty>
         <requiredProperty key="javaName"/>
         <requiredProperty key="backendPort"/>
+        <requiredProperty key="useLocalVM"/>
     </requiredProperties>
     <fileSets>
         <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/src/main/resources/archetype-resources/.travis.yml
+++ b/src/main/resources/archetype-resources/.travis.yml
@@ -1,2 +1,5 @@
 language: java
 jdk: oraclejdk8
+cache:
+  directories:
+    - "$HOME/.m2/repository"

--- a/src/main/resources/archetype-resources/init-project.sh
+++ b/src/main/resources/archetype-resources/init-project.sh
@@ -24,6 +24,12 @@ rm -fr src/main/scala/nl
 mv src/test/scala/nl/knaw/dans/easy/${moduleSubpackage} src/test/scala/${package}
 rm -fr src/test/scala/nl
 
+if [[ !${useLocalVM} ]]; then
+    echo "removing Vagrant/Ansible files"
+    rm Vagrantfile
+    rm -rf src/main/ansible
+fi
+
 echo Making helper scripts executable...
 chmod +x *.sh
 

--- a/src/main/resources/archetype-resources/init-project.sh
+++ b/src/main/resources/archetype-resources/init-project.sh
@@ -19,9 +19,9 @@ echo Setting .gitignores...
 mv _gitignore .gitignore
 
 echo Removing unnecessary directory nesting in scala source code...
-mv src/main/scala/nl/knaw/dans/easy/${moduleSubpackage} src/main/scala/${package}
+mv src/main/scala/nl/knaw/dans/${projectPrefix}/${moduleSubpackage} src/main/scala/${package}
 rm -fr src/main/scala/nl
-mv src/test/scala/nl/knaw/dans/easy/${moduleSubpackage} src/test/scala/${package}
+mv src/test/scala/nl/knaw/dans/${projectPrefix}/${moduleSubpackage} src/test/scala/${package}
 rm -fr src/test/scala/nl
 
 if [[ !${useLocalVM} ]]; then

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>${groupId}</groupId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
     <name>${name}</name>
     <url>https://github.com/DANS-KNAW/${artifactId}</url>
     <description>${description}</description>
-    <inceptionYear>2017</inceptionYear>
+    <inceptionYear>${inceptionYear}</inceptionYear>
     <properties>
         <main-class>${package}.Command</main-class>
     </properties>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -1,31 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
         <version>3.1.0</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
+
     <name>${name}</name>
     <url>https://github.com/DANS-KNAW/${artifactId}</url>
     <description>${description}</description>
     <inceptionYear>${inceptionYear}</inceptionYear>
+
     <properties>
         <main-class>${package}.Command</main-class>
     </properties>
+
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${artifactId}</developerConnection>
         <tag>HEAD</tag>
     </scm>
+
     <dependencies>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
+        <!-- testing -->
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.12</artifactId>
@@ -34,17 +37,11 @@
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_2.12</artifactId>
         </dependency>
+
+        <!-- Scala utils -->
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.12</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
@@ -54,6 +51,22 @@
             <groupId>com.github.pathikrit</groupId>
             <artifactId>better-files_2.12</artifactId>
         </dependency>
+        <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-scala-lib_2.12</artifactId>
+        </dependency>
+
+        <!-- Apache Commons -->
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-daemon</groupId>
+            <artifactId>commons-daemon</artifactId>
+        </dependency>
+
+        <!-- service -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
@@ -71,15 +84,14 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>
         </dependency>
+
+        <!-- logging -->
         <dependency>
-            <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-scalate_2.12</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-daemon</groupId>
-            <artifactId>commons-daemon</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
         </dependency>
     </dependencies>
+
     <repositories>
         <repository>
             <id>DANS</id>
@@ -89,6 +101,7 @@
             <url>http://maven.dans.knaw.nl/</url>
         </repository>
     </repositories>
+
     <pluginRepositories>
         <pluginRepository>
             <id>DANS</id>
@@ -98,6 +111,7 @@
             <url>http://maven.dans.knaw.nl/</url>
         </pluginRepository>
     </pluginRepositories>
+
     <build>
         <plugins>
             <plugin>
@@ -127,6 +141,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>rpm</id>

--- a/src/main/resources/archetype-resources/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/resources/archetype-resources/src/main/assembly/dist/cfg/application.properties
@@ -1,8 +1,9 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
+#set ($PROJECTPREFIX = ${projectPrefix.toUpperCase()})
 ${symbol_pound}
-${symbol_pound} EASY Module configuration file
+${symbol_pound} ${PROJECTPREFIX} Module configuration file
 ${symbol_pound}
 ${symbol_pound} Please, modify the configuration below to match your environment. Also, delete and/or modify
 ${symbol_pound} this description.

--- a/src/main/resources/archetype-resources/src/main/assembly/dist/cfg/logback-service.xml
+++ b/src/main/resources/archetype-resources/src/main/assembly/dist/cfg/logback-service.xml
@@ -14,5 +14,5 @@
     <root level="warn">
         <appender-ref ref="FILE" />
     </root>
-    <logger name="nl.knaw.dans.easy" level="info" />
+    <logger name="nl.knaw.dans.${projectPrefix}" level="info" />
 </configuration>

--- a/src/main/resources/archetype-resources/src/main/assembly/dist/cfg/logback.xml
+++ b/src/main/resources/archetype-resources/src/main/assembly/dist/cfg/logback.xml
@@ -17,5 +17,5 @@
 	<root level="warn">
 		<appender-ref ref="FILE" />
 	</root>
-	<logger name="nl.knaw.dans.easy" level="info" />
+	<logger name="nl.knaw.dans.${projectPrefix}" level="info" />
 </configuration>

--- a/src/main/resources/archetype-resources/src/main/scala/Command.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/Command.scala
@@ -3,11 +3,9 @@
 #set($symbol_escape = '\ ')
 package ${package}
 
-import java.nio.file.Paths
-
+import better.files.File
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import resource._
 
 import scala.language.reflectiveCalls
 import scala.util.control.NonFatal
@@ -16,7 +14,7 @@ import scala.util.{ Failure, Try }
 object Command extends App with DebugEnhancedLogging {
   type FeedBackMessage = String
 
-  val configuration = Configuration(Paths.get(System.getProperty("app.home")))
+  val configuration = Configuration(File(System.getProperty("app.home")))
   val commandLine: CommandLineOptions = new CommandLineOptions(args, configuration) {
     verify()
   }
@@ -38,7 +36,7 @@ object Command extends App with DebugEnhancedLogging {
   }
 
   private def runAsService(app: ${javaName}App): Try[FeedBackMessage] = Try {
-    val service = new ${javaName}Service(configuration.properties.getInt("daemon.http.port"), app)
+    val service = new ${javaName}Service(configuration.serverPort, app)
     Runtime.getRuntime.addShutdownHook(new Thread("service-shutdown") {
       override def run(): Unit = {
         service.stop()

--- a/src/main/resources/archetype-resources/src/main/scala/Command.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/Command.scala
@@ -36,7 +36,9 @@ object Command extends App with DebugEnhancedLogging {
   }
 
   private def runAsService(app: ${javaName}App): Try[FeedBackMessage] = Try {
-    val service = new ${javaName}Service(configuration.serverPort, app)
+    val service = new ${javaName}Service(configuration.serverPort, Map(
+      "/" -> new ${javaName}Servlet(app, configuration.version),
+    ))
     Runtime.getRuntime.addShutdownHook(new Thread("service-shutdown") {
       override def run(): Unit = {
         service.stop()

--- a/src/main/resources/archetype-resources/src/main/scala/ServiceStarter.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/ServiceStarter.scala
@@ -16,7 +16,9 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
     logger.info("Initializing service...")
     val configuration = Configuration(File(System.getProperty("app.home")))
     app = new ${javaName}App(configuration)
-    service = new ${javaName}Service(configuration.serverPort, app)
+    service = new ${javaName}Service(configuration.serverPort, Map(
+      "/" -> new ${javaName}Servlet(app, configuration.version),
+    ))
     logger.info("Service initialized.")
   }
 

--- a/src/main/resources/archetype-resources/src/main/scala/ServiceStarter.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/ServiceStarter.scala
@@ -3,9 +3,8 @@
 #set( $symbol_escape = '\' )
 package ${package}
 
-import java.nio.file.Paths
-
-import nl.knaw.dans.lib.error.TryExtensions
+import better.files.File
+import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.daemon.{ Daemon, DaemonContext }
 
@@ -15,9 +14,9 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
 
   override def init(context: DaemonContext): Unit = {
     logger.info("Initializing service...")
-    val configuration = Configuration(Paths.get(System.getProperty("app.home")))
+    val configuration = Configuration(File(System.getProperty("app.home")))
     app = new ${javaName}App(configuration)
-    service = new ${javaName}Service(configuration.properties.getInt("daemon.http.port"), app)
+    service = new ${javaName}Service(configuration.serverPort, app)
     logger.info("Service initialized.")
   }
 

--- a/src/main/resources/archetype-resources/src/main/scala/__javaName__Service.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/__javaName__Service.scala
@@ -4,7 +4,6 @@
 package ${package}
 
 import javax.servlet.ServletContext
-
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.ServletContextHandler
@@ -13,35 +12,41 @@ import org.scalatra.servlet.ScalatraListener
 
 import scala.util.Try
 
-class ${javaName}Service(serverPort: Int, app: ${javaName}App) extends DebugEnhancedLogging {
+class ${javaName}Service(serverPort: Int,
+                         servlets: Map[String, ScalatraServlet]) extends DebugEnhancedLogging {
 
-  import logger._
-
-  private val server = new Server(serverPort)
-  private val context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
-  context.addEventListener(new ScalatraListener() {
-    override def probeForCycleClass(classLoader: ClassLoader): (String, LifeCycle) = {
-      ("anonymous", new LifeCycle {
-        override def init(context: ServletContext): Unit = {
-          context.mount(new ${javaName}Servlet(app), "/")
-        }
-      })
-    }
-  })
-  server.setHandler(context)
-  info(s"HTTP port is ${symbol_dollar}{ serverPort }")
+  private val server = new Server(serverPort) {
+    setHandler(
+      new ServletContextHandler(ServletContextHandler.NO_SESSIONS) {
+        addEventListener(
+          new ScalatraListener() {
+            override def probeForCycleClass(classLoader: ClassLoader): (String, LifeCycle) = {
+              ("anonymous", new LifeCycle {
+                override def init(context: ServletContext): Unit = {
+                  for ((path, servlet) <- servlets)
+                    context.mount(servlet, path)
+                }
+              })
+            }
+          }
+        )
+      }
+    )
+  }
+  logger.info(s"HTTP port is ${symbol_dollar}serverPort")
 
   def start(): Try[Unit] = Try {
-    info("Starting service...")
+    logger.info("Starting service...")
     server.start()
   }
 
   def stop(): Try[Unit] = Try {
-    info("Stopping service...")
+    logger.info("Stopping service...")
     server.stop()
   }
 
   def destroy(): Try[Unit] = Try {
     server.destroy()
+    logger.info("Destroyed service.")
   }
 }

--- a/src/main/resources/archetype-resources/src/main/scala/__javaName__Servlet.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/__javaName__Servlet.scala
@@ -6,12 +6,11 @@ package ${package}
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra._
 
-class ${javaName}Servlet(app: ${javaName}App) extends ScalatraServlet with DebugEnhancedLogging {
-  import app._
-  import logger._
+class ${javaName}Servlet(app: ${javaName}App,
+                         version: String) extends ScalatraServlet with DebugEnhancedLogging {
 
   get("/") {
     contentType = "text/plain"
-    Ok("${name} Service running...")
+    Ok(s"${name} Service running (${symbol_dollar}version)")
   }
 }

--- a/src/main/resources/archetype-resources/src/test/resources/debug-config/application.properties
+++ b/src/main/resources/archetype-resources/src/test/resources/debug-config/application.properties
@@ -1,8 +1,9 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
+#set ($PROJECTPREFIX = ${projectPrefix.toUpperCase()})
 ${symbol_pound}
-${symbol_pound} EASY Module configuration file
+${symbol_pound} ${PROJECTPREFIX} Module configuration file
 ${symbol_pound}
 ${symbol_pound} Please, modify the configuration below to match your environment. Also, delete and/or modify
 ${symbol_pound} this description.

--- a/src/main/resources/archetype-resources/src/test/resources/debug-config/logback-service.xml
+++ b/src/main/resources/archetype-resources/src/test/resources/debug-config/logback-service.xml
@@ -5,7 +5,7 @@
             <pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
         </encoder>
     </appender>
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>data/${artifactId}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>data/${artifactId}.%d{yyyy-MM-dd}.log</fileNamePattern>

--- a/src/main/resources/archetype-resources/src/test/resources/debug-config/logback-service.xml
+++ b/src/main/resources/archetype-resources/src/test/resources/debug-config/logback-service.xml
@@ -19,5 +19,5 @@
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="nl.knaw.dans.easy" level="trace"/>
+    <logger name="nl.knaw.dans.${projectPrefix}" level="trace"/>
 </configuration>

--- a/src/main/resources/archetype-resources/src/test/resources/debug-config/logback.xml
+++ b/src/main/resources/archetype-resources/src/test/resources/debug-config/logback.xml
@@ -8,7 +8,7 @@
             <pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
         </encoder>
     </appender>
-	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
+	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<file>data/${artifactId}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>data/${artifactId}.%d{yyyy-MM-dd}.log</fileNamePattern>

--- a/src/main/resources/archetype-resources/src/test/resources/debug-config/logback.xml
+++ b/src/main/resources/archetype-resources/src/test/resources/debug-config/logback.xml
@@ -22,5 +22,5 @@
 		<appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
 	</root>
-	<logger name="nl.knaw.dans.easy" level="trace"/>
+	<logger name="nl.knaw.dans.${projectPrefix}" level="trace"/>
 </configuration>

--- a/src/main/resources/archetype-resources/src/test/resources/logback.xml
+++ b/src/main/resources/archetype-resources/src/test/resources/logback.xml
@@ -12,7 +12,7 @@
     </root>
 
     <!-- Set log level during test with system property, e.g., mvn test -DLOG_LEVEL=debug -->
-    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}" />
+    <logger name="nl.knaw.dans.${projectPrefix}" level="${LOG_LEVEL:-off}" />
     <logger name="org.scalatest" level="info" />
 
 </configuration>

--- a/src/main/resources/archetype-resources/src/test/scala/CustomMatchers.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/CustomMatchers.scala
@@ -1,10 +1,7 @@
 package ${package}
 
-import java.io.File
-
+import better.files.File
 import org.scalatest.matchers.{ MatchResult, Matcher }
-
-import scala.io.Source
 
 /** Does not dump the full file but just the searched content if it is not found.
  *
@@ -15,7 +12,7 @@ trait CustomMatchers {
       def trimLines(s: String): String = s.split("\n").map(_.trim).mkString("\n")
 
       MatchResult(
-        trimLines(Source.fromFile(left).mkString).contains(trimLines(content)),
+        trimLines(left.contentAsString).contains(trimLines(content)),
         s"$left did not contain: $content",
         s"$left contains $content"
       )

--- a/src/main/resources/archetype-resources/src/test/scala/DebugConfigSpec.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/DebugConfigSpec.scala
@@ -1,7 +1,6 @@
 package ${package}
 
-import java.nio.file.{ Files, Paths }
-
+import better.files.File
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatest.{ FlatSpec, Matchers }
 
@@ -9,16 +8,19 @@ import scala.collection.JavaConverters._
 
 class DebugConfigSpec extends FlatSpec with Matchers {
 
-  "debug-config" should "contain the same files as src/main/assembly/dist/cfg" in {
-    val filesInDebugConfig = resource.managed(Files.list(Paths.get("src/test/resources/debug-config"))).acquireAndGet(_.iterator().asScala.toSet)
-    val filesInDistCfg = resource.managed(Files.list(Paths.get("src/main/assembly/dist/cfg"))).acquireAndGet(_.iterator().asScala.toSet)
+  val configDir = File("src/main/assembly/dist/cfg")
+  val debugConfigDir = File("src/test/resources/debug-config")
 
-    filesInDebugConfig.map(_.getFileName) shouldBe filesInDistCfg.map(_.getFileName)
+  "debug-config" should "contain the same files as src/main/assembly/dist/cfg" in {
+    val filesInDebugConfig = debugConfigDir.list.toSet
+    val filesInDistCfg = configDir.list.toSet
+
+    filesInDebugConfig.map(_.name) shouldBe filesInDistCfg.map(_.name)
   }
 
   it should "contain an application.properties with the same keys as the one in src/main/assembly/dist/cfg" in {
-    val propsInDebugConfig = new PropertiesConfiguration(Paths.get("src/test/resources/debug-config/application.properties").toFile)
-    val propsInDistCfg = new PropertiesConfiguration(Paths.get("src/main/assembly/dist/cfg/application.properties").toFile)
+    val propsInDebugConfig = new PropertiesConfiguration((debugConfigDir / "application.properties").toJava)
+    val propsInDistCfg = new PropertiesConfiguration((configDir / "application.properties").toJava)
 
     propsInDebugConfig.getKeys.asScala.toSet shouldBe propsInDistCfg.getKeys.asScala.toSet
   }

--- a/src/main/resources/archetype-resources/src/test/scala/ReadmeSpec.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/ReadmeSpec.scala
@@ -1,8 +1,8 @@
 package ${package}
 
-import java.io.{ ByteArrayOutputStream, File }
-import java.nio.file.Paths
+import java.io.ByteArrayOutputStream
 
+import better.files.File
 import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
@@ -28,15 +28,15 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
     val lineSeparators = s"(${ System.lineSeparator() })+"
     val options = helpInfo.split(s"${ lineSeparators }Options:$lineSeparators")(1)
     options.trim should not be empty
-    new File("README.md") should containTrimmed(options)
+    File("README.md") should containTrimmed(options)
   }
 
   "synopsis in help info" should "be part of README.md" in {
-    new File("README.md") should containTrimmed(clo.synopsis)
+    File("README.md") should containTrimmed(clo.synopsis)
   }
 
   "description line(s) in help info" should "be part of README.md and pom.xml" in {
-    new File("README.md") should containTrimmed(clo.description)
-    new File("pom.xml") should containTrimmed(clo.description)
+    File("README.md") should containTrimmed(clo.description)
+    File("pom.xml") should containTrimmed(clo.description)
   }
 }

--- a/src/main/resources/archetype-resources/src/test/scala/ReadmeSpec.scala
+++ b/src/main/resources/archetype-resources/src/test/scala/ReadmeSpec.scala
@@ -7,7 +7,11 @@ import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
 
-  private val clo = new CommandLineOptions(Array[String](), Configuration(Paths.get("src/main/assembly/dist"))) {
+  private val configuration = Configuration(
+    version = "my-version",
+    serverPort = 12345,
+  )
+  private val clo = new CommandLineOptions(Array[String](), configuration) {
     // avoids System.exit() in case of invalid arguments or "--help"
     override def verify(): Unit = {}
   }

--- a/src/test/resources/projects/basic/archetype.properties
+++ b/src/test/resources/projects/basic/archetype.properties
@@ -5,6 +5,7 @@ moduleSubpackage=testmodule
 name=Test Name
 javaName=TestName
 package=nl.knaw.dans.easy.testmodule
+projectPrefix=easy
 version=1.x-SNAPSHOT
 backendPort=20000
 useLocalVM=true

--- a/src/test/resources/projects/basic/archetype.properties
+++ b/src/test/resources/projects/basic/archetype.properties
@@ -8,3 +8,4 @@ package=nl.knaw.dans.easy.testmodule
 version=1.x-SNAPSHOT
 backendPort=20000
 useLocalVM=true
+inceptionYear=2019

--- a/src/test/resources/projects/basic/archetype.properties
+++ b/src/test/resources/projects/basic/archetype.properties
@@ -7,3 +7,4 @@ javaName=TestName
 package=nl.knaw.dans.easy.testmodule
 version=1.x-SNAPSHOT
 backendPort=20000
+useLocalVM=true


### PR DESCRIPTION
fixes EASY-2038

#### When applied it will
* upgrade the archetype to modern standards of project setup

@DANS-KNAW/easy @ChrisMuller80 for review

#### How should this be manually tested?
* pull this PR
* build `easy-module-archetype` (`mvnci`)
* `cd` to the location you want to create the new project at
* from that place, call the `generate-easy-module.sh` script
* use the version that you just build (at the time of writing this will be `2.0.4-SNAPSHOT)
* if you want to keep the local Vagrant/Ansible scripts, choose `y` for that option, otherwise type `n`
* confirm the settings and let the project be generated for you
* once the project is generated, you can `cd` into it and call `run-service.sh` from [dans-dev-tools](https://github.com/DANS-KNAW/dans-dev-tools). In a separate terminal window you can `curl` for `http://localhost:<port>/` and see the result
