### PR TITLE
intellij formatting rules for yaml

### DIFF
--- a/dans-intellij-codestyles.xml
+++ b/dans-intellij-codestyles.xml
@@ -63,6 +63,10 @@
     <option name="XML_TEXT_WRAP" value="0" />
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
   </XML>
+  <yaml>
+    <option name="SEQUENCE_ON_NEW_LINE" value="true" />
+    <option name="AUTOINSERT_SEQUENCE_MARKER" value="false" />
+  </yaml>
   <codeStyleSettings language="JAVA">
     <option name="KEEP_LINE_BREAKS" value="false" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
@@ -112,5 +116,8 @@
   </codeStyleSettings>
   <codeStyleSettings language="XML">
     <option name="RIGHT_MARGIN" value="200" />
+  </codeStyleSettings>
+  <codeStyleSettings language="yaml">
+    <option name="SOFT_MARGINS" value="100" />
   </codeStyleSettings>
 </code_scheme>

--- a/dans-intellij-codestyles.xml
+++ b/dans-intellij-codestyles.xml
@@ -118,6 +118,6 @@
     <option name="RIGHT_MARGIN" value="200" />
   </codeStyleSettings>
   <codeStyleSettings language="yaml">
-    <option name="SOFT_MARGINS" value="100" />
+    <option name="SOFT_MARGINS" value="200" />
   </codeStyleSettings>
 </code_scheme>

--- a/dans-webstorm-codestyles.xml
+++ b/dans-webstorm-codestyles.xml
@@ -25,11 +25,20 @@
     <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
     <option name="SPACES_WITHIN_IMPORTS" value="true" />
   </TypeScriptCodeStyleSettings>
+  <yaml>
+    <option name="SEQUENCE_ON_NEW_LINE" value="true" />
+    <option name="AUTOINSERT_SEQUENCE_MARKER" value="false" />
+  </yaml>
   <codeStyleSettings language="JavaScript">
     <option name="ELSE_ON_NEW_LINE" value="true" />
   </codeStyleSettings>
   <codeStyleSettings language="TypeScript">
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+  </codeStyleSettings>
+  <codeStyleSettings language="yaml">
+    <option name="SOFT_MARGINS" value="100" />
   </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
Formatting rules for YAML files, as discussed during EASY OS upgrade.

@janvanmansum you have to run the formatter with this rules on `easy-dtap` yourself.

@DANS-KNAW/easy for review