### PR TITLE
EASY-2771: set system property "http.agent"

### DIFF
--- a/src/main/resources/archetype-resources/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/resources/archetype-resources/src/main/assembly/dist/cfg/application.properties
@@ -9,3 +9,7 @@ ${symbol_pound} Please, modify the configuration below to match your environment
 ${symbol_pound} this description.
 
 daemon.http.port=${backendPort}
+
+${symbol_pound} User-Agent header used for http requests (such as retrieval of XSD schemas)
+${symbol_pound} when omitted the default value will be ${artifactId}/<version>
+${symbol_pound} http.agent=${artifactId}

--- a/src/main/resources/archetype-resources/src/main/scala/Configuration.scala
+++ b/src/main/resources/archetype-resources/src/main/scala/Configuration.scala
@@ -5,6 +5,7 @@ package ${package}
 
 import better.files.File
 import better.files.File.root
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 
 case class Configuration(version: String,
@@ -12,7 +13,7 @@ case class Configuration(version: String,
                          // other configuration properties defined in application.properties
                         )
 
-object Configuration {
+object Configuration extends DebugEnhancedLogging {
 
   def apply(home: File): Configuration = {
     val cfgPath = Seq(
@@ -24,9 +25,13 @@ object Configuration {
       setDelimiterParsingDisabled(true)
       load((cfgPath / "application.properties").toJava)
     }
+    val version = (home / "bin" / "version").contentAsString.stripLineEnd
+    val agent = properties.getString("http.agent",s"${artifactId}/${symbol_dollar}version")
+    logger.info(s"setting http.agent to $agent")
+    System.setProperty("http.agent", agent)
 
     new Configuration(
-      version = (home / "bin" / "version").contentAsString.stripLineEnd,
+      version,
       serverPort = properties.getInt("daemon.http.port"),
       // read other properties defined in application.properties
     )


### PR DESCRIPTION
fixes EASY-2771: set system property "http.agent"

#### When applied it will
* new modules won't have problems loading DC-schema's
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
